### PR TITLE
Added gitignore file and fixed boolean type error in building.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+CMakeCache.txt
+CMakeFiles/*
+Makefile
+cmake_install.cmake
+graphics
+testing

--- a/building.h
+++ b/building.h
@@ -26,7 +26,7 @@ protected:
 
     typeOfBuilding buildingType;
 
-    const static boolean GRIDLINES_ENABLED = false;
+    const static bool GRIDLINES_ENABLED = false;
 
 public:
     Building();


### PR DESCRIPTION
Hi Marcus. I was messing around in your repository a bit, and decided to a fix a few obvious things.
First was to add a gitignore file to exclude files generated from building.
The second was to correct use of "boolean" into "bool" in building.h to make it work across more  compilers .