### PR TITLE
Fixed addNode to pass raw values to addNeighbor functions instead of raw

### DIFF
--- a/plotNetwork.cpp
+++ b/plotNetwork.cpp
@@ -19,26 +19,26 @@ void PlotNetwork::addNode(PlotNode n)
     int plotIDAbove = idAbove(n.getID(), plotsPerSide);
     if(id2node.count(plotIDAbove) != 0)
     {
-        id2node[n.getID()]->addUpNeighbor(&*id2node[plotIDAbove]);
-        id2node[plotIDAbove]->addDownNeighbor(&*id2node[n.getID()]);
+        id2node[n.getID()]->addUpNeighbor(*id2node[plotIDAbove]);
+        id2node[plotIDAbove]->addDownNeighbor(*id2node[n.getID()]);
     }
     int plotIDBelow = idBelow(n.getID(), plotsPerSide);
     if(id2node.count(plotIDBelow) != 0)
     {
-        id2node[n.getID()]->addDownNeighbor(&*id2node[plotIDBelow]);
-        id2node[plotIDBelow]->addUpNeighbor(&*id2node[n.getID()]);
+        id2node[n.getID()]->addDownNeighbor(*id2node[plotIDBelow]);
+        id2node[plotIDBelow]->addUpNeighbor(*id2node[n.getID()]);
     }
     int plotIDLeft = idLeft(n.getID(), plotsPerSide);
     if(id2node.count(plotIDLeft) != 0)
     {
-        id2node[n.getID()]->addLeftNeighbor(&*id2node[plotIDLeft]);
-        id2node[plotIDLeft]->addRightNeighbor(&*id2node[n.getID()]);
+        id2node[n.getID()]->addLeftNeighbor(*id2node[plotIDLeft]);
+        id2node[plotIDLeft]->addRightNeighbor(*id2node[n.getID()]);
     }
     int plotIDRight = idRight(n.getID(), plotsPerSide);
     if(id2node.count(plotIDRight) != 0)
     {
-        id2node[n.getID()]->addRightNeighbor(&*id2node[plotIDRight]);
-        id2node[plotIDRight]->addLeftNeighbor(&*id2node[n.getID()]);
+        id2node[n.getID()]->addRightNeighbor(*id2node[plotIDRight]);
+        id2node[plotIDRight]->addLeftNeighbor(*id2node[n.getID()]);
     }
 }
 

--- a/plotNode.cpp
+++ b/plotNode.cpp
@@ -53,21 +53,21 @@ void PlotNode::initializeCenter()
 }
 
 // Setters
-void PlotNode::addLeftNeighbor(std::experimental::optional<PlotNode*> inputLeftNeighbor)
+void PlotNode::addLeftNeighbor(PlotNode &inputLeftNeighbor)
 {
-    leftNeighbor = inputLeftNeighbor;
+    leftNeighbor = &inputLeftNeighbor;
 }
-void PlotNode::addRightNeighbor(std::experimental::optional<PlotNode*> inputRightNeighbor)
+void PlotNode::addRightNeighbor(PlotNode &inputRightNeighbor)
 {
-    rightNeighbor = inputRightNeighbor;
+    rightNeighbor = &inputRightNeighbor;
 }
-void PlotNode::addUpNeighbor(std::experimental::optional<PlotNode*> inputUpNeighbor)
+void PlotNode::addUpNeighbor(PlotNode &inputUpNeighbor)
 {
-    upNeighbor = inputUpNeighbor;
+    upNeighbor = &inputUpNeighbor;
 }
-void PlotNode::addDownNeighbor(std::experimental::optional<PlotNode*> inputDownNeighbor)
+void PlotNode::addDownNeighbor(PlotNode &inputDownNeighbor)
 {
-    downNeighbor = inputDownNeighbor;
+    downNeighbor = &inputDownNeighbor;
 }
 
 // Getters

--- a/plotNode.h
+++ b/plotNode.h
@@ -34,10 +34,10 @@ public:
     void initializeCenter();
 
     // Setters
-    void addLeftNeighbor(std::experimental::optional<PlotNode*> inputLeftNeighbor);
-    void addRightNeighbor(std::experimental::optional<PlotNode*> inputRightNeighbor);
-    void addUpNeighbor(std::experimental::optional<PlotNode*> inputUpNeighbor);
-    void addDownNeighbor(std::experimental::optional<PlotNode*> inputDownNeighbor);
+    void addLeftNeighbor(PlotNode &inputLeftNeighbor);
+    void addRightNeighbor(PlotNode &inputRightNeighbor);
+    void addUpNeighbor(PlotNode &inputUpNeighbor);
+    void addDownNeighbor(PlotNode &inputDownNeighbor);
 
     // Getters
     std::experimental::optional<PlotNode*> getLeftNeighbor() const;


### PR DESCRIPTION
pointers

Functionally the same, but makes the code a lot cleaner, and removes
knowledge of smart pointers from the upper layers of the code

I explained in a DM the benefits of this patch, but I will highlight some of them here:

- The addXXXNeighbor group of methods now take a PlotPoint reference. This indicates that the lifetime (memory allocations) of these objects are associated with something else (id2node), and that they are not responsible for managing ownership of these objects. This also indicates that the values passed in by reference will not be null (which is probably what you were trying to guard against using the optional types). When you store the neighbors, the values are cast to optional anyway, so the original functionality is preserved. So overall, same function, but cleaner code.
- NOTE: by changing the types, I've altered the interface to imply that you must pass valid PlotPoint references in. If you wanted to re purpose this interface to invalidate neighbors to nullopt, you would need another set of functions